### PR TITLE
Fix SettingProvider not returning correct format

### DIFF
--- a/app/controllers/bot.js
+++ b/app/controllers/bot.js
@@ -11,7 +11,7 @@ const { stripIndents } = require('common-tags')
 const applicationConfig = require('../../config/application')
 
 module.exports = class Bot {
-    constructor() {
+    constructor () {
         this.client = new Commando.Client({
             commandPrefix: applicationConfig.defaultPrefix,
             owner: applicationConfig.owner,
@@ -56,8 +56,8 @@ module.exports = class Bot {
         }
     }
 
-    setActivity (activity, options) {
-        this.client.user.setActivity(activity || applicationConfig.defaultActivity, options)
+    setActivity (name, options) {
+        this.client.user.setActivity(name || applicationConfig.defaultActivity, options)
     }
 
     ready () {

--- a/app/controllers/settingProvider.js
+++ b/app/controllers/settingProvider.js
@@ -13,7 +13,7 @@ module.exports = class SettingProvider {
     }
 
     async getSettings (guild) {
-        return this.bot.guilds[guild.id].getData('settings')
+        return this.bot.guilds[guild.id].getData('settings') || {}
     }
 
     async set (guild, key, val) {


### PR DESCRIPTION
This PR fixes the SettingProvider not returning an empty object when the guild has not settings yet.