### PR TITLE
Hotfix/Multi-word tag arguments

### DIFF
--- a/app/commands/main/tag.js
+++ b/app/commands/main/tag.js
@@ -45,7 +45,8 @@ module.exports = class TagCommand extends Command {
                 }
             }
 
-            return message.reply(tag.tag)
+            // Don't reply but send instead to avoid confusion about for who the tag was requested.
+            return message.channel.send(tag.tag)
 
         } else {
             let list = ''

--- a/app/commands/main/tag.js
+++ b/app/commands/main/tag.js
@@ -26,9 +26,13 @@ module.exports = class TagCommand extends Command {
     }
 
     async execute (message, { name }, guild) {
+        const names = name.split(' ')
+        name = names.shift()
+
         if (name !== 'all') {
             const tag = tags.find(tag => tag.names.includes(name))
             if (!tag) return message.reply('Couldn\'t find tag!')
+
             if (tag.group === 'admin') {
                 if (!discordService.isAdmin(message.member, guild.getData('adminRoles'))) {
                     return message.reply('You do not have permission to see that tag.')
@@ -40,6 +44,7 @@ module.exports = class TagCommand extends Command {
                     }
                 }
             }
+
             return message.reply(tag.tag)
 
         } else {
@@ -51,6 +56,7 @@ module.exports = class TagCommand extends Command {
                     count++
                 }
             }
+
             const embed = new MessageEmbed()
                 .setTitle('Tags')
                 .setDescription(list)

--- a/app/content/tags.js
+++ b/app/content/tags.js
@@ -44,6 +44,6 @@ module.exports = [{
             
             YouTube does have multiple tutorials on the process, for example:
             - [Using CSG in Roblox Studio](https://youtu.be/a0iPvgKUzU0)
-            - [Or 3D modelling in Blender](https://youtu.be/TPrnSACiTJ4)
+            - [3D modelling in Blender](https://youtu.be/TPrnSACiTJ4)
         `)
 }]


### PR DESCRIPTION
When the tag command was run with a multi-word argument, the command interpreted that as a multi-word argument while it should just take the first word of the argument. This PR fixes that.