### PR TITLE
Hotfix/RoVer fetching missing Discord ID in URL

### DIFF
--- a/app/controllers/ticket.js
+++ b/app/controllers/ticket.js
@@ -100,7 +100,7 @@ class TicketController extends EventEmitter {
         let username
         let userId
         try {
-            const response = (await roVerAdapter('get', `/user/1`)).data
+            const response = (await roVerAdapter('get', `/user/${this.author.id}`)).data
             username = response.robloxUsername
             userId = response.robloxId
 


### PR DESCRIPTION
It always tried to get the information of a user with ID 1 (probably slipped through earlier), this substitutes that 1 with the Discord user's ID.

This PR resolves #79.