### PR TITLE
Fix Booster Report inaccuracy

### DIFF
--- a/app/helpers/time.js
+++ b/app/helpers/time.js
@@ -65,3 +65,11 @@ exports.getDurationString = milliseconds => {
   const seconds = Math.floor(minutesMilliseconds / (1000))
   return `${days > 0 ? days + 'd ' : ''}${hours > 0 ? hours + 'h ' : ''}${minutes > 0 ? minutes + 'm ' : ''}${seconds > 0 ? seconds + 's ' : ''}`
 }
+
+exports.diffDays = (date1, date2) => {
+  const d1 = new Date(date1)
+  const d2 = new Date(date2)
+  d1.setHours(0, 0, 0)
+  d2.setHours(0, 0, 0)
+  return Math.round(Math.abs((d1 - d2) / (24 * 60 * 60 * 1000)))
+}

--- a/app/jobs/premium-members-report.js
+++ b/app/jobs/premium-members-report.js
@@ -1,5 +1,6 @@
 'use strict'
 const pluralize = require('pluralize')
+const timeHelper = require('../helpers/time')
 
 const { MessageEmbed } = require('discord.js')
 
@@ -15,11 +16,11 @@ module.exports = async guild => {
   const monthlyPremiumMembers = []
   const now = new Date()
   for (const member of premiumMembers) {
-    const premiumDate = member.premiumSince
-    if (premiumDate.getMonth() !== now.getMonth() && premiumDate.getDate() === now.getDate()) {
+    const days = timeHelper.diffDays(member.premiumSince, now)
+    if (days !== 0 && days % 30 === 0) {
       monthlyPremiumMembers.push({
-        member: member,
-        months: now.getMonth() - premiumDate.getMonth() + (now.getFullYear() - premiumDate.getFullYear()) * 12
+        member,
+        months: days / 30
       })
     }
   }


### PR DESCRIPTION
The job now counts the amount of days between the boosting date and current date and sees someone as boosting for several months if there's a multiple of 30 dates between those dates.

Discord Nitro 1 month is 30 days long, hence why the job now calculates it this way. There's no way of knowing if a member has a yearly or monthly subscription. 
If someone has a yearly subscription, the amounts will eventually be a little off. At 360 days the job will think the user has been boosting for "12 months" while this would actually be the case at 365 days.

This PR resolves #107 