### PR TITLE
Fix/Don't show undefined if emoji can't be found

### DIFF
--- a/app/commands/main/boost-info.js
+++ b/app/commands/main/boost-info.js
@@ -38,17 +38,16 @@ module.exports = class BoostInfoCommand extends Command {
     }
     const years = Math.floor(months / 12)
     months %= 12
-    const emojis = guild.getData('emojis')
-    const emoji = guild.guild.emojis.cache.find(emoji => emoji.id === emojis.boostEmoji)
+    const emoji = this.client.mainGuild.emojis.cache.find(emoji => emoji.name.toLowerCase() === 'boost')
     if (member.user.partial) {
       await member.user.partial.fetch()
     }
 
     const embed = new MessageEmbed()
-      .setTitle(`${member.user.tag} ${emoji}`)
+      .setTitle(`${member.user.tag}${emoji ? ` ${emoji}` : ''}`)
       .setThumbnail(member.user.displayAvatarURL())
       .setDescription(`Has been boosting this server for ${years > 0 ? `**${years}** ${pluralize('year', years)}, ` : ''}**${months}** ${pluralize('month', months)} and **${days}** ${pluralize('day', days)}!`)
       .setColor(0xff73fa)
-    message.replyEmbed(embed)
+    return message.replyEmbed(embed)
   }
 }

--- a/app/jobs/premium-members-report.js
+++ b/app/jobs/premium-members-report.js
@@ -30,8 +30,7 @@ module.exports = async guild => {
     const embed = new MessageEmbed()
       .setTitle('Server Booster Report')
       .setColor(0xff73fa)
-    const emojis = guild.getData('emojis')
-    const emoji = guild.guild.emojis.cache.find(emoji => emoji.id === emojis.boostEmoji)
+    const emoji = guild.emojis.cache.find(emoji => emoji.name.toLowerCase() === 'boost')
 
     for (const { member, months } of monthlyPremiumMembers) {
       embed.addField(`${member.user.tag} ${emoji || ''}`, `Has been boosting this server for **${months}** ${pluralize('month', months)}!`)


### PR DESCRIPTION
Took me a long time but this PR fixes the bug where /boostinfo would show "undefined" in the embed's title if the command wasn't able to find the boost emoji.